### PR TITLE
ci(publish): py3.11→3.12 in publish gate (unblock v0.11.1 PyPI)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install package + dev deps
         run: |
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install hatch
         run: pip install hatch


### PR DESCRIPTION
publish.yml's test-gate + build jobs pinned python 3.11, but `requires-python>=3.12` → publish gate install failed → v0.11.1 upload skipped. Fix to 3.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)