### PR TITLE
chore(deps): raise iil-aifw floor 0.6.1 → 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.11.2] — 2026-06-14
+
+### Changed
+- **Dependency floor `iil-aifw>=0.6.1` → `>=0.11.2`** (in both the `aifw` and `all` extras). authoringfw passes `quality_level`/`priority` into `aifw.sync_completion()`/`completion()`, but aifw silently ignored those parameters until 0.11.2 (it routed every call to the catch-all `AIActionType` row). From 0.11.2 the routing cascade is actually applied, so authoringfw's quality-tier routing works for the first time. Pinning the floor guarantees the feature is present rather than a silent no-op.
+
 ## [0.11.0] — 2026-04-25
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iil-authoringfw"
-version = "0.11.1"
+version = "0.11.2"
 description = "Authoring Framework — domain schemas and orchestration base for AI-assisted creative writing"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -27,7 +27,7 @@ dependencies = [
 
 [project.optional-dependencies]
 aifw = [
-    "iil-aifw>=0.6.1",
+    "iil-aifw>=0.11.2",  # quality_level/priority routing only works from 0.11.2 (was silently ignored before)
 ]
 yaml = [
     "pyyaml>=6.0",
@@ -37,7 +37,7 @@ promptfw = [
 ]
 all = [
     "pyyaml>=6.0",
-    "iil-aifw>=0.6.1",
+    "iil-aifw>=0.11.2",  # quality_level/priority routing only works from 0.11.2 (was silently ignored before)
     "iil-promptfw>=0.5.5",
 ]
 dev = [


### PR DESCRIPTION
## Why

authoringfw passes `quality_level` and `priority` into `aifw.sync_completion()` / `completion()` (`base.py` `_call_llm`/`_call_llm_async`, plus `research/`), and exposes them as first-class `ContentTask` fields. But **aifw silently ignored those parameters until 0.11.2** — `completion()` called the legacy `get_model_config(action_code)` and routed every call to the catch-all `AIActionType` row. So authoringfw's quality-tier routing has never actually worked.

aifw 0.11.2 (released today) wires the routing cascade into the completion path, so the feature works for the first time.

## Change

- `iil-aifw>=0.6.1` → `>=0.11.2` in both the `aifw` and `all` extras (it's an optional dependency — matches the guarded import in `base.py`).
- Bump authoringfw `0.11.1` → `0.11.2` so the new constraint ships, + CHANGELOG entry.

The old floor (`>=0.6.1`, no cap) already *allowed* 0.11.2; this raise **guarantees** the routing fix is present rather than leaving the core feature a silent no-op on any environment resolving to 0.6–0.11.1.

## ⚠️ Behavioral note (review point)

With 0.11.2, calls that pass `quality_level`/`priority` now resolve via the routing cascade instead of always the catch-all row. Whether model selection actually changes depends on the **deployment DB**: if it has `quality_level`/`priority`-specific `AIActionType` rows, authoringfw will now route to them (different models + costs). If only catch-all rows exist, behaviour is unchanged. Operator check: `python manage.py check_aifw_config` / `AIActionType.objects.exclude(quality_level=None).exists()`.

Pre-existing (not addressed here, candidate follow-ups): `_get_action_config()` fetches config without `quality_level`/`priority`, so `prompt_template_key` always comes from the catch-all row even when routing to a quality-specific model; and `_resolve_quality_level()` reads `config.get("default_quality_level")`, a key `ActionConfig` does not define (always `None`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)