### PR TITLE
chore(deps): bump iil-aifw to >=0.11.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 
 [project.optional-dependencies]
 aifw = [
-    "iil-aifw>=0.11.2",  # quality_level/priority routing only works from 0.11.2 (was silently ignored before)
+    "iil-aifw>=0.11.4",  # quality_level/priority routing only works from 0.11.2 (was silently ignored before)
 ]
 yaml = [
     "pyyaml>=6.0",
@@ -37,7 +37,7 @@ promptfw = [
 ]
 all = [
     "pyyaml>=6.0",
-    "iil-aifw>=0.11.2",  # quality_level/priority routing only works from 0.11.2 (was silently ignored before)
+    "iil-aifw>=0.11.4",  # quality_level/priority routing only works from 0.11.2 (was silently ignored before)
     "iil-promptfw>=0.5.5",
 ]
 dev = [


### PR DESCRIPTION
Bump `iil-aifw` floor 0.11.2 → 0.11.4 (both occurrences). Picks up privacy_mode (issue #8). Default stays `full` — no behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)