### PR TITLE
chore(agent-readiness): CLAUDE.md + AGENT_HANDOVER + config alignment

### DIFF
--- a/AGENT_HANDOVER.md
+++ b/AGENT_HANDOVER.md
@@ -1,0 +1,46 @@
+# AGENT_HANDOVER.md — iil-authoringfw
+
+Living current-state / next-priorities handover for the next agent or contributor.
+`NEXT.md` is an auto-generated cache, not the source of truth — this file is.
+
+## Current state (observed)
+
+- Library package: dist `iil-authoringfw`, import `authoringfw`. `requires-python >= 3.12`.
+- In-repo version `0.11.2` (`pyproject.toml`); root `__init__.py` resolves
+  `__version__` from installed metadata via `importlib.metadata`.
+- Tests: **186 passing** (`make test`). Ruff lint clean (`make lint`).
+- No mypy / type-check target exists in this repo.
+- Broad flat public API: root `__init__.py` re-exports ~60 names with `__all__`.
+
+## Recently landed
+
+- Tier-1 agent-readiness (this change): `CLAUDE.md` + `AGENT_HANDOVER.md`,
+  `__version__` now from `importlib.metadata` (was hardcoded `"0.11.0"`, stale vs
+  pyproject), config alignment — ruff `target-version py311 → py312`, classifiers
+  cleaned (duplicate `3.12` → `3` + `3.12`). No behavior change.
+- `iil-aifw` floor raised to `>=0.11.4` (#7) so `quality_level`/`priority` routing
+  is actually applied rather than a silent no-op.
+- Publish gate + build moved py3.11 → 3.12 (#5).
+
+## Known issues / TODO
+
+- **Unpublished version drift**: `pyproject.toml` = `0.11.2`, PyPI latest = `0.11.1`.
+  `0.11.2` was bumped in-repo but never published. Do **not** auto-publish; a
+  release is a deliberate, gated human step (`/release`). Just be aware imports
+  from PyPI lag the repo by one patch.
+- Hardcoded version strings remain inside the `__init__.py` module docstring
+  ("New in 0.x.y …" changelog notes) — cosmetic only; `__version__` itself is now
+  metadata-driven.
+- No mypy config — types are unchecked. Out of scope for Tier 1.
+
+## Next priorities
+
+1. Decide whether to publish `0.11.2` (closes the PyPI drift) — gated, human call.
+2. Optional: add a `[tool.mypy]` config + `make types` target for Tier 2.
+3. Keep `__all__` in sync as new public symbols are added.
+
+## Pointers
+
+- Operating guide: `CLAUDE.md` (setup / test-lint / module map / release gate).
+- Public API: `src/authoringfw/__init__.py` (`__all__`).
+- Changelog: `CHANGELOG.md`. Release flow: platform `/release` workflow (OIDC).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md — iil-authoringfw
+
+Repo operating guide for autonomous agents and contributors. Repo-specific
+overrides take precedence over user-level `~/.claude/CLAUDE.md`.
+
+## What this is
+
+`iil-authoringfw` (dist name) / `authoringfw` (import name) is the **Authoring
+Framework**: domain schemas and an orchestration base for AI-assisted creative
+writing. It provides Pydantic domain models (story / character / scene / style /
+world), runtime-checkable adapter Protocols, and content orchestrators
+(chapter, summary, research, analysis, text reformatting). It is a library — no
+service, no DB. LLM integration is optional (`iil-aifw`, `iil-promptfw` extras).
+
+## Setup
+
+```bash
+make install              # pip install -e ".[dev]"  (editable + dev deps)
+# or, if PEP 668 blocks system pip, use a venv:
+python3 -m venv .venv && . .venv/bin/activate && pip install -e ".[dev]"
+```
+
+`requires-python >= 3.12`. Optional extras: `aifw`, `promptfw`, `yaml`, `all`.
+
+## Test / lint / types
+
+```bash
+make test     # python3 -m pytest tests/ --tb=short -q   (186 tests)
+make test-v   # verbose
+make lint     # ruff check src/ tests/
+```
+
+There is **no mypy / type-check target** configured in this repo (no
+`[tool.mypy]`); `make types` does not exist. Tests use `pytest-asyncio`
+(`asyncio_mode = "auto"`) and `pytest-mock`.
+
+## Architecture — public API map
+
+The package exposes a **broad, flat public API**: the root `authoringfw/__init__.py`
+re-exports ~60 names from its subpackages and declares `__all__`. Submodule map:
+
+| Module | Public surface |
+|---|---|
+| `authoringfw.base` / `.types` | `BaseContentOrchestrator`, `ContentTask`, `ContentResult` |
+| `authoringfw.exceptions` | `AuthoringFWError`, `OrchestrationError`, `ConfigurationError`, `TemplateNotFoundError` |
+| `authoringfw.schema.*` | `StoryProfile`, `CharacterProfile`, `SceneProfile`, `StyleProfile`, `WorldContext`, `Location`, `VersionMetadata`, `PhaseSnapshot`, `ChangeType` |
+| `authoringfw.adapters` | runtime-checkable Protocols: `IStoryAdapter`, `ICharacterAdapter`, `ISceneAdapter`, `IStyleAdapter`, `IWorldAdapter`, `ILocationAdapter` |
+| `authoringfw.writing` | `ChapterOrchestrator`, `ChunkedChapterOrchestrator`, `SummaryOrchestrator`, task/result types, `compute_max_tokens`, `compute_words_per_chunk` |
+| `authoringfw.research` | `ResearchOrchestrator`, `ResearchTask`, `ResearchResult` |
+| `authoringfw.analysis` | `StyleAnalysisOrchestrator`, `PlotAnalysisOrchestrator`, `AnalysisTask`, `AnalysisResult` |
+| `authoringfw.text` | `TextReformatter`, `ReformatTask`, `ReformatResult` (domain-agnostic transforms) |
+| `authoringfw.formats` | `FormatProfile`, `WorkflowPhase`, `get_format` (`roman`, `essay`, `serie`, `scientific`) |
+| `authoringfw.planning` | `PlanningFieldConfig`, `get_planning_config` |
+| `authoringfw.consistency` | `ConsistencyChecker`, `ConsistencyReport`, `ConsistencyIssue` |
+| `authoringfw.content_types` | `ContentTypeConfig`, `get_content_type_config`, `list_content_types` (loads `StyleProfile` from YAML eagerly at import) |
+| `authoringfw.templates` | story prompt templates + `story_registry`, `render_story_template` |
+
+`__version__` resolves from installed package metadata via `importlib.metadata`,
+falling back to `"0.0.0.dev0"` in an uninstalled source checkout.
+
+## Conventions
+
+- Commits: `[feat|fix|refactor|docs|test|chore](scope): description`.
+- Test names: `test_should_{expected_behavior}` (a naming-convention check warns
+  on legacy names; opt out per-test only when justified).
+- Ruff `line-length = 100`, `target-version = py312`.
+- Public API is the `__all__` in the root `__init__.py` — add new exports there.
+
+## Release (GATED — do NOT run autonomously)
+
+Publishing to PyPI is **gated** and never happens on merge. Versions are bumped
+and released only on an explicit human instruction, via the platform `/release`
+workflow (OIDC trusted publishing; no API token). Do not touch `version =` in
+`pyproject.toml`, the `__version__` resolution, or tag/release as part of routine
+work.
+
+## Known issues
+
+- Unpublished version drift: `pyproject.toml` is `0.11.2`, PyPI latest is
+  `0.11.1` — `0.11.2` was bumped in-repo but not published. Leave as-is; a
+  release is a deliberate, gated step. See `AGENT_HANDOVER.md`.
+- `NEXT.md` is an **auto-generated cache**, not a source of truth.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -71,4 +71,4 @@ asyncio_mode = "auto"
 
 [tool.ruff]
 line-length = 100
-target-version = "py311"
+target-version = "py312"

--- a/src/authoringfw/__init__.py
+++ b/src/authoringfw/__init__.py
@@ -16,9 +16,30 @@ New in 0.5.0: research/ sub-domain — ResearchOrchestrator.
 New in 0.6.2: text/ sub-domain — TextReformatter, ReformatTask, ReformatResult.
               Generic post-hoc text transformation (no domain coupling).
               Usable from iil-researchfw, bfagent, or any consumer.
+
+Public submodule map (the broad multi-module public API; see CLAUDE.md):
+  authoringfw.base / .types   — BaseContentOrchestrator, ContentTask / ContentResult
+  authoringfw.exceptions      — AuthoringFWError hierarchy
+  authoringfw.schema.*        — domain models (story, character, scene, style,
+                                world, versioning)
+  authoringfw.adapters        — runtime-checkable adapter Protocols (I*Adapter)
+  authoringfw.writing         — Chapter / Summary orchestrators + chunking helpers
+  authoringfw.research        — ResearchOrchestrator
+  authoringfw.analysis        — Style / Plot analysis orchestrators
+  authoringfw.text            — TextReformatter (domain-agnostic transforms)
+  authoringfw.formats         — FormatProfile / WorkflowPhase / get_format
+  authoringfw.planning        — planning field configuration
+  authoringfw.consistency     — ConsistencyChecker + report types
+  authoringfw.content_types   — data-driven content-type configuration
+  authoringfw.templates       — story prompt templates + registry
 """
 
-__version__ = "0.11.0"
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+try:
+    __version__ = _pkg_version("iil-authoringfw")
+except PackageNotFoundError:  # pragma: no cover - source checkout without install
+    __version__ = "0.0.0.dev0"
 
 from authoringfw.analysis import (
     AnalysisResult,


### PR DESCRIPTION
## Tier 1 — agent-readiness (iil family)

Part of the PyPI agent-readiness program: make this package safe and predictable
for an autonomous agent (or a stronger model) to build on. Follows the reference
template in achimdehnert/iil-adrfw#11. **No behavior change.**

### Changes

- **`src/authoringfw/__init__.py`** — `__version__` now resolves from package
  metadata via `importlib.metadata` (fallback `"0.0.0.dev0"` in an uninstalled
  source checkout). It was hardcoded `"0.11.0"`, already stale vs `pyproject`'s
  `0.11.2`. Added a public submodule map to the module docstring. Existing
  `__all__` kept unchanged (root re-exports ~60 names).
- **`pyproject.toml`** — ruff `target-version` `py311 → py312` (was a config-lie
  vs `requires-python>=3.12`); classifiers cleaned (duplicate `3.12` → `3` +
  `3.12`). `requires-python` untouched.
- **`CLAUDE.md`** — repo operating guide: setup, test/lint (no mypy target here),
  public-API module map for the broad multi-module surface, conventions, gated
  release, known issues.
- **`AGENT_HANDOVER.md`** — living current-state / next-priorities handover. Flags
  the unpublished version drift (`0.11.2` in-repo vs `0.11.1` on PyPI). `NEXT.md`
  is an auto-generated cache, not the source of truth.

`Makefile` already existed (family convention `make install/test/lint`) — not
touched.

### Verification

- `make test` → **186 passed**
- `make lint` (ruff) → clean
- `python3 -c "import authoringfw; authoringfw.__version__"` resolves from metadata

> Note: this PR does **not** touch versions or trigger any release. Publishing the
> in-repo `0.11.2` (to close the PyPI drift) remains a deliberate, gated human step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)